### PR TITLE
If the pxToEm method ist not available Equal-Heights tried to execute it either way.

### DIFF
--- a/jQuery.equalHeights.js
+++ b/jQuery.equalHeights.js
@@ -23,7 +23,7 @@ $.fn.equalHeights = function(px) {
 		$(this).children().each(function(i){
 			if ($(this).height() > currentTallest) { currentTallest = $(this).height(); }
 		});
-		if (!px || !Number.prototype.pxToEm) currentTallest = currentTallest.pxToEm(); //use ems unless px is specified
+		if (!px && Number.prototype.pxToEm) currentTallest = currentTallest.pxToEm(); //use ems unless px is specified
 		// for ie6, set height since min-height isn't supported
 		if ($.browser.msie && $.browser.version == 6.0) { $(this).children().css({'height': currentTallest}); }
 		$(this).children().css({'min-height': currentTallest}); 


### PR DESCRIPTION
I think you ment this expression like this:
only use pxToEm iff ((px is not set) AND (pxToEm is present))
