### PR TITLE
Fixed $.browser.msie issue with jQuery 1.9, detect minHeight support instead

### DIFF
--- a/jQuery.equalHeights.js
+++ b/jQuery.equalHeights.js
@@ -25,7 +25,7 @@ $.fn.equalHeights = function(px) {
 		});
     if (!px && Number.prototype.pxToEm) currentTallest = currentTallest.pxToEm(); //use ems unless px is specified
 		// for ie6, set height since min-height isn't supported
-		if ($.browser.msie && $.browser.version == 6.0) { $(this).children().css({'height': currentTallest}); }
+		if (typeof(document.body.style.minHeight) === "undefined") { $(this).children().css({'height': currentTallest}); }
 		$(this).children().css({'min-height': currentTallest}); 
 	});
 	return this;
@@ -40,7 +40,7 @@ $.fn.equalWidths = function(px) {
 		});
 		if(!px && Number.prototype.pxToEm) currentWidest = currentWidest.pxToEm(); //use ems unless px is specified
 		// for ie6, set width since min-width isn't supported
-		if ($.browser.msie && $.browser.version == 6.0) { $(this).children().css({'width': currentWidest}); }
+		if (typeof(document.body.style.minHeight) === "undefined") { $(this).children().css({'width': currentWidest}); }
 		$(this).children().css({'min-width': currentWidest}); 
 	});
 	return this;


### PR DESCRIPTION
The plugin no longer works with jQuery 1.9 since `$.browser` has been removed. Instead of browser sniffing, it's better to check directly for the property or function we need anyway, so this changes from using an IE6 check to just checking directly for `minHeight` support.

This also fixes #8.