### PR TITLE
Improve performance by eliminating repeated instantiation of jquery objects

### DIFF
--- a/jQuery.equalHeights.js
+++ b/jQuery.equalHeights.js
@@ -19,14 +19,17 @@
 
 $.fn.equalHeights = function(px) {
 	$(this).each(function(){
-		var currentTallest = 0;
-		$(this).children().each(function(i){
-			if ($(this).height() > currentTallest) { currentTallest = $(this).height(); }
+		var currentTallest = 0,
+				$this = $(this),
+				$children = $(this).children();
+		$children.each(function(i){
+			var $child = $(this);
+			if ($child.height() > currentTallest) { currentTallest = $child.height(); }
 		});
-    if (!px && Number.prototype.pxToEm) currentTallest = currentTallest.pxToEm(); //use ems unless px is specified
+		if (!px && Number.prototype.pxToEm) currentTallest = currentTallest.pxToEm(); //use ems unless px is specified
 		// for ie6, set height since min-height isn't supported
-		if ($.browser.msie && $.browser.version == 6.0) { $(this).children().css({'height': currentTallest}); }
-		$(this).children().css({'min-height': currentTallest}); 
+		if ($.browser.msie && $.browser.version == 6.0) { $children.css({'height': currentTallest}); }
+		$children.css({'min-height': currentTallest}); 
 	});
 	return this;
 };
@@ -34,14 +37,17 @@ $.fn.equalHeights = function(px) {
 // just in case you need it...
 $.fn.equalWidths = function(px) {
 	$(this).each(function(){
-		var currentWidest = 0;
-		$(this).children().each(function(i){
-				if($(this).width() > currentWidest) { currentWidest = $(this).width(); }
+		var currentWidest = 0,
+				$this = $(this),
+				$children = $this.children();
+		$children.each(function(i){
+				var $child = $(this);
+				if($child.width() > currentWidest) { currentWidest = $child.width(); }
 		});
 		if(!px && Number.prototype.pxToEm) currentWidest = currentWidest.pxToEm(); //use ems unless px is specified
 		// for ie6, set width since min-width isn't supported
-		if ($.browser.msie && $.browser.version == 6.0) { $(this).children().css({'width': currentWidest}); }
-		$(this).children().css({'min-width': currentWidest}); 
+		if ($.browser.msie && $.browser.version == 6.0) { $.children.css({'width': currentWidest}); }
+		$children.css({'min-width': currentWidest}); 
 	});
 	return this;
 };


### PR DESCRIPTION
There are repeated calls to `$(this)` and `$(this).children()` throughout the plugin. Every time `$(this)` is called, jQuery instantiates another jQuery object wrapped around `this`, and every time `$(this).children()` is called, it instantiates another jQuery object around `this` and re-runs the sizzle selectors to find the children and instantiates new objects around the children set.

This all results in a lot of wasted memory, especially for a large or complex DOM or lots of rows where this plugin is being called. This can be helped by caching the objects into a variable the first time and then just referencing the variable.

See [this jsPerf](http://jsperf.com/caching-jquery-objects-perf) for benchmarks, and [this is a good talk](http://addyosmani.com/blog/jquery-performance-tips-2011/) as well.