### PR TITLE
Options hash

### DIFF
--- a/jQuery.equalHeights.js
+++ b/jQuery.equalHeights.js
@@ -17,16 +17,17 @@
  *  07.24.2008 v 2.0 - added support for widths
 --------------------------------------------------------------------*/
 
-$.fn.equalHeights = function(px) {
+$.fn.equalHeights = function(options) {
+	options = $.extend({px: false, filter: 'children', selector: '*'}, options);
 	$(this).each(function(){
 		var currentTallest = 0,
 				$this = $(this),
-				$children = $(this).children();
+				$children = $this[options.filter](options.selector);
 		$children.each(function(i){
 			var $child = $(this);
 			if ($child.height() > currentTallest) { currentTallest = $child.height(); }
 		});
-		if (!px && Number.prototype.pxToEm) currentTallest = currentTallest.pxToEm(); //use ems unless px is specified
+		if (!options.px && Number.prototype.pxToEm) currentTallest = currentTallest.pxToEm(); //use ems unless px is specified
 		// for ie6, set height since min-height isn't supported
 		if ($.browser.msie && $.browser.version == 6.0) { $children.css({'height': currentTallest}); }
 		$children.css({'min-height': currentTallest}); 
@@ -35,16 +36,18 @@ $.fn.equalHeights = function(px) {
 };
 
 // just in case you need it...
-$.fn.equalWidths = function(px) {
+$.fn.equalWidths = function(options) {
+	options = $.extend({px: false, filter: 'children', selector: '*'}, options);
 	$(this).each(function(){
 		var currentWidest = 0,
 				$this = $(this),
-				$children = $this.children();
+				$children = $this.find(options.selector);
+				$children = $this[options.filter](options.selector);
 		$children.each(function(i){
 				var $child = $(this);
 				if($child.width() > currentWidest) { currentWidest = $child.width(); }
 		});
-		if(!px && Number.prototype.pxToEm) currentWidest = currentWidest.pxToEm(); //use ems unless px is specified
+		if(!options.px && Number.prototype.pxToEm) currentWidest = currentWidest.pxToEm(); //use ems unless px is specified
 		// for ie6, set width since min-width isn't supported
 		if ($.browser.msie && $.browser.version == 6.0) { $.children.css({'width': currentWidest}); }
 		$children.css({'min-width': currentWidest}); 

--- a/jQuery.equalHeights.js
+++ b/jQuery.equalHeights.js
@@ -19,14 +19,17 @@
 
 $.fn.equalHeights = function(px) {
 	$(this).each(function(){
-		var currentTallest = 0;
-		$(this).children().each(function(i){
-			if ($(this).height() > currentTallest) { currentTallest = $(this).height(); }
+		var currentTallest = 0,
+				$this = $(this),
+				$children = $(this).children();
+		$children.each(function(i){
+			var $child = $(this);
+			if ($child.height() > currentTallest) { currentTallest = $child.height(); }
 		});
-    if (!px && Number.prototype.pxToEm) currentTallest = currentTallest.pxToEm(); //use ems unless px is specified
+		if (!px && Number.prototype.pxToEm) currentTallest = currentTallest.pxToEm(); //use ems unless px is specified
 		// for ie6, set height since min-height isn't supported
-		if ($.browser.msie && $.browser.version == 6.0) { $(this).children().css({'height': currentTallest}); }
-		$(this).children().css({'min-height': currentTallest}); 
+		if ($.browser.msie && $.browser.version == 6.0) { $children.css({'height': currentTallest}); }
+		$children.css({'min-height': currentTallest}); 
 	});
 	return this;
 };
@@ -34,14 +37,17 @@ $.fn.equalHeights = function(px) {
 // just in case you need it...
 $.fn.equalWidths = function(px) {
 	$(this).each(function(){
-		var currentWidest = 0;
-		$(this).children().each(function(i){
-				if($(this).width() > currentWidest) { currentWidest = $(this).width(); }
+		var currentWidest = 0,
+				$this = $(this),
+				$children = $this.children();
+		$children.each(function(i){
+				var $child = $(this);
+				if($child.width() > currentWidest) { currentWidest = $child.width(); }
 		});
 		if(!px && Number.prototype.pxToEm) currentWidest = currentWidest.pxToEm(); //use ems unless px is specified
 		// for ie6, set width since min-width isn't supported
-		if ($.browser.msie && $.browser.version == 6.0) { $(this).children().css({'width': currentWidest}); }
-		$(this).children().css({'min-width': currentWidest}); 
+		if ($.browser.msie && $.browser.version == 6.0) { $.children.css({'width': currentWidest}); }
+		$children.css({'min-width': currentWidest}); 
 	});
 	return this;
 };


### PR DESCRIPTION
I had a need to use `equalHeights` on some rows where the target elements that needed their heights set were not the direct children of the actual row element. So, I made an options hash. This plugin currently had one option for `px`, so I moved that into the options hash and made it default to `false` if nothing is passed in, just as before.

So the default options are:

```js
{px: false, filter: 'children', selector: '*'}
```

...which leaves the default behavior identical to what it is currently. Instead of hardcoding `$(this).children()`, it now would be `$(this)['children']('*')`, which is the same as before, just written differently so as to make the actual values easy to customize. For example, I'm currently using the plugin like this:

```js
$('.row').equalHeights({filter: 'find', selector: '.profile'})
```

This allows me to actually set the heights on the `.profile` elements which are deeply nested within `.row` (thus why I change the `filter` setting to 'find' instead of 'children').

You could also set the heights on only some of the children with options like this:

```js
$('.row').equalHeights({filter: 'children', selector: '.odd'})
```

Note that this pull request depends on #11, since the caching of the jQuery objects made it so that the new options only needed to be used in one place rather than using them over and over in the repeated selector calls.